### PR TITLE
Improved mTLS README section by mentioning different ssl modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Finally, update your Kafka Connector JSON configuration to enable the mTLS conne
 
 * **File Paths:** The paths for `serverSslCert` and `keystore` must point to the correct locations on your worker nodes.
 * **Passwords:** Replace `<mtls_password>` and `<keystore_password>` with your actual secure values.
-* **SSL Mode:** Set `<ssl_mode>` to either `verify-full` or `verify-ca` (to skip hostname verification) based on your security requirements.
+* **SSL Mode:** Set `<ssl_mode>` to either `verify-full` or `verify-ca` (to skip hostname verification) based on your security requirements. For more information and a complete list of available SSL/TLS configuration options, refer to the [SingleStore JDBC Driver - TLS Parameters](https://docs.singlestore.com/cloud/developer-resources/connect-with-application-development-tools/connect-with-java-jdbc/the-singlestore-jdbc-driver/#tls-parameters) documentation.
 
 ```
 "config": {
@@ -246,7 +246,6 @@ Finally, update your Kafka Connector JSON configuration to enable the mTLS conne
 }
 ```
 
-For a complete list of available SSL/TLS configuration options, refer to the [SingleStore JDBC Driver TLS Parameters documentation](https://docs.singlestore.com/cloud/developer-resources/connect-with-application-development-tools/connect-with-java-jdbc/the-singlestore-jdbc-driver/#tls-parameters).
 
 ## Setting up development environment
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Finally, update your Kafka Connector JSON configuration to enable the mTLS conne
 
 * **File Paths:** The paths for `serverSslCert` and `keystore` must point to the correct locations on your worker nodes.
 * **Passwords:** Replace `<mtls_password>` and `<keystore_password>` with your actual secure values.
-* **SSL Mode:** Set `<ssl_mode>` to either `verify-full` or `verify-ca` (to skip hostname verification) based on your security requirements. For more information and a complete list of available SSL/TLS configuration options, refer to the [SingleStore JDBC Driver - TLS Parameters](https://docs.singlestore.com/cloud/developer-resources/connect-with-application-development-tools/connect-with-java-jdbc/the-singlestore-jdbc-driver/#tls-parameters) documentation.
+* **SSL Mode:** Set `<ssl_mode>` to either `verify-full` (encryption, certificate validation and hostname verification) or `verify-ca` (encryption, certificates validation, BUT no hostname verification) based on your security requirements. For more information and a complete list of available SSL/TLS configuration options, refer to the [SingleStore JDBC Driver - TLS Parameters](https://docs.singlestore.com/cloud/developer-resources/connect-with-application-development-tools/connect-with-java-jdbc/the-singlestore-jdbc-driver/#tls-parameters) documentation.
 
 ```
 "config": {

--- a/README.md
+++ b/README.md
@@ -230,13 +230,14 @@ Finally, update your Kafka Connector JSON configuration to enable the mTLS conne
 
 * **File Paths:** The paths for `serverSslCert` and `keystore` must point to the correct locations on your worker nodes.
 * **Passwords:** Replace `<mtls_password>` and `<keystore_password>` with your actual secure values.
+* **SSL Mode:** Set `<ssl_mode>` to either `verify-full` or `verify-ca` (to skip hostname verification) based on your security requirements.
 
 ```
 "config": {
     ...
     "connection.user" : "mtls_user",
     "connection.password" : "<mtls_password>",
-    "params.sslMode" : "verify-full",
+    "params.sslMode" : "<ssl_mode>",
     "params.serverSslCert": "/path/to/singlestore_bundle.pem",
     "params.keystore": "/path/to/client-keystore.p12",
     "params.keyStorePassword": "<keystore_password>",
@@ -244,6 +245,8 @@ Finally, update your Kafka Connector JSON configuration to enable the mTLS conne
     ...
 }
 ```
+
+For a complete list of available SSL/TLS configuration options, refer to the [SingleStore JDBC Driver TLS Parameters documentation](https://docs.singlestore.com/cloud/developer-resources/connect-with-application-development-tools/connect-with-java-jdbc/the-singlestore-jdbc-driver/#tls-parameters).
 
 ## Setting up development environment
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change in `README.md` that clarifies configuration values; no runtime code paths are modified.
> 
> **Overview**
> Updates the mTLS section of `README.md` to document `params.sslMode` choices (`verify-full` vs `verify-ca`) with a link to SingleStore JDBC TLS parameter docs, and replaces the hardcoded example value with an `<ssl_mode>` placeholder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea7bf6ca565e09475d5a465a78d0ddd63ef54a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->