### PR TITLE
chore: update CI actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,16 +2,16 @@ name: Release
 
 on:
   push:
-    tags: "v*"
+    tags: ["v*"]
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up JDK 8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '8'
           distribution: 'temurin'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Get supported versions of SingleStore
         id: get_versions
         uses: singlestore-labs/singlestore-supported-versions@main
+        with:
+          include_rc: true
 
   test:
     needs: fetch-s2-versions
@@ -29,7 +31,7 @@ jobs:
           }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Remove unnecessary pre-installed toolchains for free disk spaces
         run: |
           echo "=== BEFORE ==="
@@ -47,7 +49,7 @@ jobs:
           echo "=== AFTER ==="
           df -h
       - name: Set up JDK 8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '8'
           distribution: 'temurin'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only changes; main risk is unexpected workflow behavior changes from upgrading `actions/checkout`/`setup-java` and expanding the test matrix to include RC versions.
> 
> **Overview**
> Updates GitHub Actions workflows to use `actions/checkout@v5` and `actions/setup-java@v5`, and normalizes the release tag trigger to `tags: ["v*"]`.
> 
> Expands CI coverage by configuring `singlestore-supported-versions` with `include_rc: true`, causing the test matrix to run against SingleStore release candidates as well.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e5378b4dfcdd9812981049d3c4dc02dcb7162b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->